### PR TITLE
Fix header to be old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,15 +6,11 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
         
         <!-- Dark Mode Toggle Button -->
         <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode" title="Toggle dark/light mode">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -64,26 +64,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -872,13 +852,6 @@ body {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
This PR addresses the request to revert the header to the old version by:

- Removing the "Course Materials Assistant" header
- Removing the subheader "Ask questions about courses, instructors, and content"
- Removing the horizontal row below the subheader
- Keeping the theme toggle functionality intact
- Updating the page title to "RAG Chatbot"

Closes #1

Generated with [Claude Code](https://claude.ai/code)